### PR TITLE
Use absolute path for templates directory

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,11 +29,12 @@ from app.routers import auth as auth_router
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Candidate Intake API")
-templates = Jinja2Templates(directory="templates")
-app.add_middleware(SessionMiddleware, secret_key="super-secret-key")
 
 # Static & uploads (absolute paths)
 BASE_DIR = Path(__file__).resolve().parent.parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+app.add_middleware(SessionMiddleware, secret_key="super-secret-key")
+
 FRONTEND_DIST_DIR = BASE_DIR / "static" / "forms"
 FRONTEND_INDEX_FILE = FRONTEND_DIST_DIR / "index.html"
 


### PR DESCRIPTION
## Summary
- resolve the backend base directory and initialize Jinja2Templates with an absolute templates path so FastAPI can locate templates regardless of the working directory

## Testing
- DATABASE_URL=sqlite:///./test.db uvicorn app.main:app --reload --app-dir backend
- curl -i http://127.0.0.1:8000/admin

------
https://chatgpt.com/codex/tasks/task_e_68d161264870832da8ab920d1f2188ca