### PR TITLE
Clean up intake form submission handling

### DIFF
--- a/backend/frontend/src/components/Can-intake-form.tsx
+++ b/backend/frontend/src/components/Can-intake-form.tsx
@@ -88,7 +88,6 @@ function IntakeForm() {
         body: JSON.stringify(payload),
       });
 
-      codex/update-router-to-include-candidate-form-1366dg
       const contentType = response.headers.get("content-type") ?? "";
       if (!contentType.includes("application/json")) {
         const fallbackText = await response.text().catch(() => "");
@@ -109,25 +108,16 @@ function IntakeForm() {
         | null;
 
       if (!response.ok) {
-      if (!response.ok) {
-        const data = await response.json().catch(() => null);
-      main
         const detail = typeof data?.detail === "string" ? data.detail : null;
         throw new Error(detail ?? "Unable to submit the form.");
       }
 
-      codex/update-router-to-include-candidate-form-1366dg
       const detail = typeof data?.detail === "string" ? data.detail : null;
       const id = typeof data?.id === "number" ? data.id : null;
       const baseMessage = detail
         ? detail.charAt(0).toUpperCase() + detail.slice(1)
         : "Candidate successfully submitted.";
       setSuccess(id ? `${baseMessage} (ID ${id}).` : baseMessage);
-
-      const data = await response.json().catch(() => null);
-      const detail = typeof data?.detail === "string" ? data.detail : null;
-      setSuccess(detail ? detail.charAt(0).toUpperCase() + detail.slice(1) : "Candidate successfully submitted.");
-      main
       resetForm();
     } catch (submissionError) {
       setError(


### PR DESCRIPTION
## Summary
- remove leftover conflict artifacts from the candidate intake form component
- ensure the intake form submission keeps the JSON content-type validation and success banner logic intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1f8f21258832d85fdba4c2f3a73d8