### PR TITLE
Fix Vite dev server base path

### DIFF
--- a/backend/frontend/vite.config.ts
+++ b/backend/frontend/vite.config.ts
@@ -3,11 +3,23 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  base: '/static/forms/',
-  build: {
-    outDir: '../static/forms',
-    emptyOutDir: true,
-  },
+export default defineConfig(({ command }) => {
+  const isDev = command === 'serve'
+
+  return {
+    plugins: [react(), tailwindcss()],
+    base: isDev ? '/' : '/static/forms/',
+    server: {
+      proxy: {
+        '/api': {
+          target: 'http://localhost:8000',
+          changeOrigin: true,
+        },
+      },
+    },
+    build: {
+      outDir: '../static/forms',
+      emptyOutDir: true,
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- serve the Vite dev build from the root path while keeping the production base under /static/forms
- add a development proxy so /api requests hit the FastAPI backend during local runs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d22c565664832dba0656a53b1bb3f5