### PR TITLE
Fix portal template resolution for admin profile view

### DIFF
--- a/backend/app/routers/portal.py
+++ b/backend/app/routers/portal.py
@@ -9,9 +9,10 @@ from pathlib import Path
 from .. import models, schemas, crud, database
 
 router = APIRouter(prefix="/portal", tags=["portal"])
-templates = Jinja2Templates(directory="templates")
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
-UPLOAD_DIR = Path("uploads")
+UPLOAD_DIR = BASE_DIR / "uploads"
 UPLOAD_DIR.mkdir(exist_ok=True)
 
 


### PR DESCRIPTION
## Summary
- ensure the portal router resolves templates from the backend/templates directory
- align the upload directory with the backend base path so asset paths are consistent

## Testing
- pytest *(fails: hangs during collection in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3be66fd1c832d8106347ea61b7df8