### PR TITLE
Organize admin router into focused modules

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,26 +1,24 @@
-# =========================
-# Imports
-# =========================
+"""Main FastAPI application entry point.
+
+The bulk of the business logic lives in dedicated routers so that this module
+remains focused on application wiring and the small set of shared routes.
+"""
+
 from pathlib import Path
-import secrets, hashlib
 
-from fastapi import FastAPI, Request, Depends, Form
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import HTMLResponse, RedirectResponse, FileResponse
 from fastapi.templating import Jinja2Templates
-from fastapi import HTTPException
-from starlette.middleware.sessions import SessionMiddleware
 from sqlalchemy.orm import Session
-from pydantic import EmailStr
-
-from datetime import datetime, timedelta
-from sqlalchemy import or_, func
+from starlette.middleware.sessions import SessionMiddleware
 
 from app import models
 from app.database import Base, engine, get_db
+from app.routers import admin as admin_router
+from app.routers import auth as auth_router
 from app.routers import candidates as candidates_router
 from app.routers import portal as portal_router
-from app.routers import auth as auth_router
 
 
 # =========================
@@ -41,16 +39,13 @@ FRONTEND_INDEX_FILE = FRONTEND_DIST_DIR / "index.html"
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 app.mount("/uploads", StaticFiles(directory=str(BASE_DIR / "uploads")), name="uploads")
 
-# Status buckets used by Applicants/Workers views
-WORKER_STATUSES = {"Hired", "Employee", "Active"}
-APPLICANT_STATUSES_EXCLUDE = WORKER_STATUSES
-
 
 # =========================
 # Public / Authenticated Landing
 # =========================
 @app.get("/", response_class=HTMLResponse)
 def home(request: Request, db: Session = Depends(get_db)):
+    """Render the dashboard for authenticated users or redirect to login."""
     user_session = request.session.get("user")
     if not user_session:
         return RedirectResponse(url="/auth/login", status_code=303)
@@ -66,339 +61,10 @@ def home(request: Request, db: Session = Depends(get_db)):
 
 @app.get("/candidate-form", response_class=HTMLResponse)
 def candidate_form(request: Request):
+    """Serve the React-built candidate form when present, otherwise fallback."""
     if FRONTEND_INDEX_FILE.exists():
         return FileResponse(FRONTEND_INDEX_FILE, media_type="text/html")
     return templates.TemplateResponse("index.html", {"request": request})
-
-
-# =========================
-# Admin: Dashboard
-# =========================
-@app.get("/admin", response_class=HTMLResponse)
-def admin_dashboard(request: Request, db: Session = Depends(get_db)):
-    candidates_count = db.query(models.Candidate).count()
-    users_count = db.query(models.User).count()
-    training_count = 0
-
-    return templates.TemplateResponse(
-        "admin_dashboard.html",
-        {
-            "request": request,
-            "candidates_count": candidates_count,
-            "users_count": users_count,
-            "training_count": training_count,
-        },
-    )
-
-
-# =========================
-# Admin: Candidates (raw list)
-# =========================
-@app.get("/admin/candidates", response_class=HTMLResponse)
-def list_candidates(request: Request, db: Session = Depends(get_db)):
-    candidates = db.query(models.Candidate).all()
-    return templates.TemplateResponse("candidates.html", {"request": request, "candidates": candidates})
-
-
-# =========================
-# Admin: Workers (Users with worker-status Candidate) + Filters
-# =========================
-@app.get("/admin/users", response_class=HTMLResponse)
-def list_users(request: Request, db: Session = Depends(get_db)):
-    # ---- read query params
-    role      = (request.query_params.get("role")      or "").strip()
-    status    = (request.query_params.get("status")    or "").strip()
-    date_from = (request.query_params.get("date_from") or "").strip()
-    date_to   = (request.query_params.get("date_to")   or "").strip()
-    q         = (request.query_params.get("q")         or "").strip()
-
-    # ---- base candidate filters
-    cand_filters = [models.Candidate.status.in_(WORKER_STATUSES)]
-    if status:
-        cand_filters = [models.Candidate.status == status]
-    if role:
-        cand_filters.append(models.Candidate.job_title == role)
-
-    # joining date range — using applied_on
-    def _parse_iso(d: str):
-        try:
-            return datetime.fromisoformat(d)
-        except Exception:
-            return None
-
-    start_dt = _parse_iso(date_from)
-    end_dt   = _parse_iso(date_to)
-    if start_dt:
-        cand_filters.append(models.Candidate.applied_on >= start_dt)
-    if end_dt:
-        cand_filters.append(models.Candidate.applied_on < (end_dt + timedelta(days=1)))
-
-    # keywords across candidate + user fields
-    if q:
-        like = f"%{q}%"
-        cand_filters.append(
-            or_(
-                models.Candidate.first_name.ilike(like),
-                models.Candidate.last_name.ilike(like),
-                models.Candidate.email.ilike(like),
-                models.Candidate.mobile.ilike(like),
-                models.User.username.ilike(like),
-                models.User.email.ilike(like),
-            )
-        )
-
-    # ---- single-pass query with join
-    rows = (
-        db.query(models.User, models.Candidate)
-          .join(models.Candidate, models.Candidate.user_id == models.User.id)
-          .filter(*cand_filters)
-          .order_by(func.lower(models.User.username))
-          .all()
-    )
-
-    users = [u for (u, _c) in rows]
-    user_candidates = {u.id: c for (u, c) in rows}
-
-    # ---- dropdown data
-    roles = [
-        r for (r,) in (
-            db.query(models.Candidate.job_title)
-              .filter(models.Candidate.status.in_(WORKER_STATUSES))
-              .filter(models.Candidate.job_title.isnot(None))
-              .distinct()
-              .all()
-        ) if r
-    ]
-    roles.sort(key=lambda s: s.lower()) # case-insensitive sort
-
-    status_options = sorted(WORKER_STATUSES)
-
-    flash = request.session.pop("flash", None) # One time flash message
-    return templates.TemplateResponse( # render the users.html template
-        "users.html",
-        {
-            "request": request,
-            "users": users,
-            "user_candidates": user_candidates,
-            "flash": flash,
-
-            # filter state/choices
-            "roles": roles,
-            "status_options": status_options,
-            "role": role,
-            "status": status,
-            "date_from": date_from,
-            "date_to": date_to,
-            "q": q,
-        },
-    )
-
-
-# Alias: keep old /admin/staffs working (redirect to canonical /admin/users)
-@app.get("/admin/staffs")
-def list_staffs_redirect():
-    return RedirectResponse(url="/admin/users", status_code=307)
-
-
-# =========================
-# Admin: Training / Assessments / Mixed Views
-# =========================
-@app.get("/admin/training", response_class=HTMLResponse)
-def list_training(request: Request):
-    training = []
-    return templates.TemplateResponse("training_list.html", {"request": request, "training": training})
-
-@app.get("/admin/candidate-assessment", response_class=HTMLResponse)
-def candidate_assessment(request: Request):
-    return templates.TemplateResponse("candidate_assessment.html", {"request": request})
-
-@app.get("/admin/candidates-users", response_class=HTMLResponse)
-def list_candidates_users(request: Request, db: Session = Depends(get_db)):
-    candidates = db.query(models.Candidate).all()
-    users = db.query(models.User).all()
-    return templates.TemplateResponse(
-        "candidates_users.html",
-        {"request": request, "candidates": candidates, "users": users},
-    )
-
-
-# =========================
-# Admin: Add Employee (create User + Candidate)
-# =========================
-@app.get("/admin/users/new", response_class=HTMLResponse)
-def new_user_form(request: Request):
-    return templates.TemplateResponse("user_new.html", {"request": request})
-
-@app.post("/admin/users/new", response_class=HTMLResponse)
-def create_user_and_candidate(
-    request: Request,
-    username: str = Form(...),
-    email: EmailStr = Form(...),
-    first_name: str = Form(""),
-    last_name: str = Form(""),
-    job_title: str = Form(""),
-    mobile: str = Form(""),
-    status: str = Form("Applied"),
-    db: Session = Depends(get_db),
-):
-    existing = db.query(models.User).filter(
-        (models.User.username == username) | (models.User.email == email)
-    ).first()
-    if existing:
-        return templates.TemplateResponse(
-            "user_new.html",
-            {"request": request, "error": "Username or email already exists."},
-            status_code=400,
-        )
-
-    temp_password = secrets.token_urlsafe(8)
-    hashed = hashlib.sha256(temp_password.encode()).hexdigest()  # use your real hasher if available
-
-    user = models.User(username=username, email=email, hashed_password=hashed)
-    db.add(user); db.commit(); db.refresh(user)
-
-    cand = models.Candidate(
-        first_name=first_name or "",
-        last_name=last_name or "",
-        email=email,
-        mobile=mobile or "",
-        job_title=job_title or "",
-        status=status or "Applied",
-        user_id=user.id,
-    )
-    db.add(cand); db.commit()
-
-    request.session["flash"] = f"User created. Temporary password: {temp_password}"
-    return RedirectResponse(url="/admin/users", status_code=303)
-
-
-# =========================
-# Admin: Applicants (list + convert)
-# =========================
-@app.get("/admin/applicants", response_class=HTMLResponse)
-def list_applicants(request: Request, db: Session = Depends(get_db)):
-    applicants = (
-        db.query(models.Candidate)
-        .filter(~models.Candidate.status.in_(APPLICANT_STATUSES_EXCLUDE))
-        .all()
-    )
-    flash = request.session.pop("flash", None)
-    return templates.TemplateResponse("applicants.html", {"request": request, "applicants": applicants, "flash": flash})
-
-@app.get("/admin/applicants/{candidate_id}/profile")
-def ensure_profile_and_open(candidate_id: int, request: Request, db: Session = Depends(get_db)):
-    cand = db.query(models.Candidate).filter(models.Candidate.id == candidate_id).first()
-    if not cand:
-        raise HTTPException(status_code=404, detail="Candidate not found")
-
-    # ensure linked user (reuse by id/email, else create)
-    user = db.query(models.User).filter(models.User.id == cand.user_id).first() if cand.user_id else None
-    if not user and cand.email:
-        user = db.query(models.User).filter(models.User.email == cand.email).first()
-
-    if not user:
-        base_username = (
-            cand.email.split("@")[0] if cand.email and "@" in cand.email
-            else f"{(cand.first_name or '').lower()}.{(cand.last_name or '').lower()}".strip(".")
-        ) or f"user{cand.id}"
-
-        # ensure unique username
-        username = base_username
-        i = 1
-        while db.query(models.User).filter(models.User.username == username).first():
-            i += 1
-            username = f"{base_username}{i}"
-
-        temp_password = secrets.token_urlsafe(8)
-        hashed = hashlib.sha256(temp_password.encode()).hexdigest()
-
-        user = models.User(
-            username=username,
-            email=cand.email or f"{username}@example.com",
-            hashed_password=hashed,
-        )
-        db.add(user)
-        db.flush()           # get user.id
-        cand.user_id = user.id
-        db.add(cand)
-        db.commit()
-
-        request.session["flash"] = f"Created user '{username}'. Temporary password: {temp_password}"
-
-    return RedirectResponse(url=f"/portal/profile/admin/{user.id}", status_code=303)
-
-# Simple convert (kept for history; overridden below by the robust version)
-@app.post("/admin/applicants/{candidate_id}/convert", response_class=HTMLResponse)
-def convert_applicant_to_worker(candidate_id: int, request: Request, db: Session = Depends(get_db)):
-    cand = db.query(models.Candidate).filter(models.Candidate.id == candidate_id).first()
-    if not cand:
-        request.session["flash"] = "Candidate not found."
-        return RedirectResponse(url="/admin/applicants", status_code=303)
-
-    cand.status = "Hired"
-    db.add(cand); db.commit()
-
-    request.session["flash"] = (f"{cand.first_name or ''} {cand.last_name or ''}".strip() or "Candidate") + " moved to Workers."
-    return RedirectResponse(url="/admin/users", status_code=303)
-
-# Robust convert (ensures linked User; placed AFTER simple version)
-@app.post("/admin/applicants/{candidate_id}/convert", response_class=HTMLResponse)
-def convert_applicant_to_worker(candidate_id: int, request: Request, db: Session = Depends(get_db)):
-    cand = db.query(models.Candidate).filter(models.Candidate.id == candidate_id).first()
-    if not cand:
-        request.session["flash"] = "Candidate not found."
-        return RedirectResponse(url="/admin/applicants", status_code=303)
-
-    # Ensure the candidate has a linked user
-    user = None
-    if cand.user_id:
-        user = db.query(models.User).filter(models.User.id == cand.user_id).first()
-
-    if not user:
-        # Try to reuse existing user by email
-        if cand.email:
-            user = db.query(models.User).filter(models.User.email == cand.email).first()
-
-        if not user:
-            # Create a new user
-            base_username = (
-                cand.email.split("@")[0] if cand.email and "@" in cand.email
-                else f"{(cand.first_name or '').lower()}.{(cand.last_name or '').lower()}".strip(".")
-            ) or f"user{cand.id}"
-
-            # Ensure unique username
-            username = base_username
-            i = 1
-            while db.query(models.User).filter(models.User.username == username).first():
-                i += 1
-                username = f"{base_username}{i}"
-
-            temp_password = secrets.token_urlsafe(8)
-            hashed = hashlib.sha256(temp_password.encode()).hexdigest()  # use your normal hasher if you have one
-
-            user = models.User(
-                username=username,
-                email=cand.email or f"{username}@example.com",
-                hashed_password=hashed,
-            )
-            db.add(user)
-            db.flush()  # get user.id without a full commit yet
-            # Show the temp password once
-            request.session["flash"] = f"Created user '{username}'. Temporary password: {temp_password}"
-
-        cand.user_id = user.id  # link candidate -> user
-
-    # Mark as worker
-    cand.status = "Hired"
-    db.add(cand)
-    db.commit()
-
-    # If user already existed and we didn't set flash above, show a generic message
-    if "flash" not in request.session:
-        full_name = f"{cand.first_name or ''} {cand.last_name or ''}".strip() or "Candidate"
-        request.session["flash"] = f"{full_name} moved to Workers."
-
-    return RedirectResponse(url="/admin/users", status_code=303)
 
 
 # =========================
@@ -407,3 +73,4 @@ def convert_applicant_to_worker(candidate_id: int, request: Request, db: Session
 app.include_router(candidates_router.router)
 app.include_router(auth_router.router)
 app.include_router(portal_router.router)
+app.include_router(admin_router.router)

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Application router modules."""

--- a/backend/app/routers/admin/__init__.py
+++ b/backend/app/routers/admin/__init__.py
@@ -1,0 +1,8 @@
+"""Admin-facing HTML views grouped by domain."""
+
+from .router import router  # noqa: F401
+from . import applicants  # noqa: F401
+from . import dashboard  # noqa: F401
+from . import users  # noqa: F401
+
+__all__ = ["router"]

--- a/backend/app/routers/admin/applicants.py
+++ b/backend/app/routers/admin/applicants.py
@@ -1,0 +1,128 @@
+"""Routes for managing applicant-to-worker workflows."""
+
+import hashlib
+import secrets
+
+from fastapi import Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy.orm import Session
+
+from app import models
+from app.database import get_db
+
+from .router import APPLICANT_STATUSES_EXCLUDE, router, templates
+
+
+def _existing_user_for_candidate(candidate: models.Candidate, db: Session):
+    if candidate.user_id:
+        user = db.query(models.User).filter(models.User.id == candidate.user_id).first()
+        if user:
+            return user
+    if candidate.email:
+        return db.query(models.User).filter(models.User.email == candidate.email).first()
+    return None
+
+
+def _generate_candidate_username(candidate: models.Candidate, db: Session) -> str:
+    if candidate.email and "@" in candidate.email:
+        base_username = candidate.email.split("@")[0]
+    else:
+        base_username = (
+            f"{(candidate.first_name or '').lower()}.{(candidate.last_name or '').lower()}".strip(".")
+        )
+    base_username = base_username or f"user{candidate.id}"
+
+    username = base_username
+    suffix = 1
+    while db.query(models.User).filter(models.User.username == username).first():
+        suffix += 1
+        username = f"{base_username}{suffix}"
+    return username
+
+
+def _create_user_for_candidate(candidate: models.Candidate, db: Session):
+    username = _generate_candidate_username(candidate, db)
+    temp_password = secrets.token_urlsafe(8)
+    hashed = hashlib.sha256(temp_password.encode()).hexdigest()
+
+    user = models.User(
+        username=username,
+        email=candidate.email or f"{username}@example.com",
+        hashed_password=hashed,
+    )
+    db.add(user)
+    db.flush()
+
+    candidate.user_id = user.id
+    db.add(candidate)
+    return user, temp_password
+
+
+def _ensure_candidate_user(candidate: models.Candidate, db: Session):
+    user = _existing_user_for_candidate(candidate, db)
+    if user:
+        return user, None
+    return _create_user_for_candidate(candidate, db)
+
+
+@router.get("/applicants", response_class=HTMLResponse)
+def list_applicants(request: Request, db: Session = Depends(get_db)):
+    """List applicants who have not yet been converted to workers."""
+    applicants = (
+        db.query(models.Candidate)
+        .filter(~models.Candidate.status.in_(APPLICANT_STATUSES_EXCLUDE))
+        .all()
+    )
+    flash = request.session.pop("flash", None)
+    return templates.TemplateResponse(
+        "applicants.html",
+        {"request": request, "applicants": applicants, "flash": flash},
+    )
+
+
+@router.get("/applicants/{candidate_id}/profile")
+def ensure_profile_and_open(
+    candidate_id: int, request: Request, db: Session = Depends(get_db)
+):
+    """Ensure a candidate has a linked user before opening the profile view."""
+    cand = db.query(models.Candidate).filter(models.Candidate.id == candidate_id).first()
+    if not cand:
+        raise HTTPException(status_code=404, detail="Candidate not found")
+
+    user, temp_password = _ensure_candidate_user(cand, db)
+    if temp_password:
+        request.session["flash"] = (
+            f"Created user '{user.username}'. Temporary password: {temp_password}"
+        )
+        db.commit()
+
+    return RedirectResponse(url=f"/portal/profile/admin/{user.id}", status_code=303)
+
+
+@router.post("/applicants/{candidate_id}/convert", response_class=HTMLResponse)
+def convert_applicant_to_worker(
+    candidate_id: int, request: Request, db: Session = Depends(get_db)
+):
+    """Convert an applicant into a worker, ensuring a user exists."""
+    cand = db.query(models.Candidate).filter(models.Candidate.id == candidate_id).first()
+    if not cand:
+        request.session["flash"] = "Candidate not found."
+        return RedirectResponse(url="/admin/applicants", status_code=303)
+
+    user, temp_password = _ensure_candidate_user(cand, db)
+    if temp_password:
+        request.session["flash"] = (
+            f"Created user '{user.username}'. Temporary password: {temp_password}"
+        )
+
+    cand.status = "Hired"
+    if user:
+        cand.user_id = user.id
+    db.add(cand)
+    db.commit()
+
+    if "flash" not in request.session:
+        full_name = f"{cand.first_name or ''} {cand.last_name or ''}".strip() or "Candidate"
+        request.session["flash"] = f"{full_name} moved to Workers."
+
+    return RedirectResponse(url="/admin/users", status_code=303)

--- a/backend/app/routers/admin/dashboard.py
+++ b/backend/app/routers/admin/dashboard.py
@@ -1,0 +1,65 @@
+"""Dashboard and general overview pages."""
+
+from fastapi import Depends, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy.orm import Session
+
+from app import models
+from app.database import get_db
+
+from .router import router, templates
+
+
+@router.get("", response_class=HTMLResponse)
+def dashboard(request: Request, db: Session = Depends(get_db)):
+    """Render the administrator dashboard."""
+    candidates_count = db.query(models.Candidate).count()
+    users_count = db.query(models.User).count()
+    training_count = 0
+
+    return templates.TemplateResponse(
+        "admin_dashboard.html",
+        {
+            "request": request,
+            "candidates_count": candidates_count,
+            "users_count": users_count,
+            "training_count": training_count,
+        },
+    )
+
+
+@router.get("/candidates", response_class=HTMLResponse)
+def list_candidates(request: Request, db: Session = Depends(get_db)):
+    """List all candidate records."""
+    candidates = db.query(models.Candidate).all()
+    return templates.TemplateResponse(
+        "candidates.html", {"request": request, "candidates": candidates}
+    )
+
+
+@router.get("/candidates-users", response_class=HTMLResponse)
+def list_candidates_users(request: Request, db: Session = Depends(get_db)):
+    """Render a combined view of candidates and users."""
+    candidates = db.query(models.Candidate).all()
+    users = db.query(models.User).all()
+    return templates.TemplateResponse(
+        "candidates_users.html",
+        {"request": request, "candidates": candidates, "users": users},
+    )
+
+
+@router.get("/training", response_class=HTMLResponse)
+def list_training(request: Request):
+    """Placeholder page for training content."""
+    training = []
+    return templates.TemplateResponse(
+        "training_list.html", {"request": request, "training": training}
+    )
+
+
+@router.get("/candidate-assessment", response_class=HTMLResponse)
+def candidate_assessment(request: Request):
+    """Render the candidate assessment template."""
+    return templates.TemplateResponse(
+        "candidate_assessment.html", {"request": request}
+    )

--- a/backend/app/routers/admin/router.py
+++ b/backend/app/routers/admin/router.py
@@ -1,0 +1,15 @@
+"""Shared admin router configuration and resources."""
+
+from pathlib import Path
+
+from fastapi import APIRouter
+from fastapi.templating import Jinja2Templates
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+WORKER_STATUSES = {"Hired", "Employee", "Active"}
+APPLICANT_STATUSES_EXCLUDE = WORKER_STATUSES

--- a/backend/app/routers/admin/users.py
+++ b/backend/app/routers/admin/users.py
@@ -1,0 +1,163 @@
+"""Routes for managing employees and worker records."""
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta
+
+from fastapi import Depends, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import EmailStr
+from sqlalchemy import func, or_
+from sqlalchemy.orm import Session
+
+from app import models
+from app.database import get_db
+
+from .router import WORKER_STATUSES, router, templates
+
+
+@router.get("/users", response_class=HTMLResponse)
+def list_users(request: Request, db: Session = Depends(get_db)):
+    """List workers with optional filtering."""
+    role = (request.query_params.get("role") or "").strip()
+    status = (request.query_params.get("status") or "").strip()
+    date_from = (request.query_params.get("date_from") or "").strip()
+    date_to = (request.query_params.get("date_to") or "").strip()
+    q = (request.query_params.get("q") or "").strip()
+
+    cand_filters = [models.Candidate.status.in_(WORKER_STATUSES)]
+    if status:
+        cand_filters = [models.Candidate.status == status]
+    if role:
+        cand_filters.append(models.Candidate.job_title == role)
+
+    def _parse_iso(value: str):
+        try:
+            return datetime.fromisoformat(value)
+        except Exception:
+            return None
+
+    start_dt = _parse_iso(date_from)
+    end_dt = _parse_iso(date_to)
+    if start_dt:
+        cand_filters.append(models.Candidate.applied_on >= start_dt)
+    if end_dt:
+        cand_filters.append(models.Candidate.applied_on < (end_dt + timedelta(days=1)))
+
+    if q:
+        like = f"%{q}%"
+        cand_filters.append(
+            or_(
+                models.Candidate.first_name.ilike(like),
+                models.Candidate.last_name.ilike(like),
+                models.Candidate.email.ilike(like),
+                models.Candidate.mobile.ilike(like),
+                models.User.username.ilike(like),
+                models.User.email.ilike(like),
+            )
+        )
+
+    rows = (
+        db.query(models.User, models.Candidate)
+        .join(models.Candidate, models.Candidate.user_id == models.User.id)
+        .filter(*cand_filters)
+        .order_by(func.lower(models.User.username))
+        .all()
+    )
+
+    users = [user for (user, _cand) in rows]
+    user_candidates = {user.id: cand for (user, cand) in rows}
+
+    roles = [
+        r
+        for (r,) in (
+            db.query(models.Candidate.job_title)
+            .filter(models.Candidate.status.in_(WORKER_STATUSES))
+            .filter(models.Candidate.job_title.isnot(None))
+            .distinct()
+            .all()
+        )
+        if r
+    ]
+    roles.sort(key=lambda value: value.lower())
+
+    status_options = sorted(WORKER_STATUSES)
+
+    flash = request.session.pop("flash", None)
+    return templates.TemplateResponse(
+        "users.html",
+        {
+            "request": request,
+            "users": users,
+            "user_candidates": user_candidates,
+            "flash": flash,
+            "roles": roles,
+            "status_options": status_options,
+            "role": role,
+            "status": status,
+            "date_from": date_from,
+            "date_to": date_to,
+            "q": q,
+        },
+    )
+
+
+@router.get("/staffs")
+def list_staffs_redirect():
+    """Retain backwards compatibility for the previous /admin/staffs route."""
+    return RedirectResponse(url="/admin/users", status_code=307)
+
+
+@router.get("/users/new", response_class=HTMLResponse)
+def new_user_form(request: Request):
+    """Render the form to create a new employee."""
+    return templates.TemplateResponse("user_new.html", {"request": request})
+
+
+@router.post("/users/new", response_class=HTMLResponse)
+def create_user_and_candidate(
+    request: Request,
+    username: str = Form(...),
+    email: EmailStr = Form(...),
+    first_name: str = Form(""),
+    last_name: str = Form(""),
+    job_title: str = Form(""),
+    mobile: str = Form(""),
+    status: str = Form("Applied"),
+    db: Session = Depends(get_db),
+):
+    """Create a User and matching Candidate record."""
+    existing = (
+        db.query(models.User)
+        .filter((models.User.username == username) | (models.User.email == email))
+        .first()
+    )
+    if existing:
+        return templates.TemplateResponse(
+            "user_new.html",
+            {"request": request, "error": "Username or email already exists."},
+            status_code=400,
+        )
+
+    temp_password = secrets.token_urlsafe(8)
+    hashed = hashlib.sha256(temp_password.encode()).hexdigest()
+
+    user = models.User(username=username, email=email, hashed_password=hashed)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    candidate = models.Candidate(
+        first_name=first_name or "",
+        last_name=last_name or "",
+        email=email,
+        mobile=mobile or "",
+        job_title=job_title or "",
+        status=status or "Applied",
+        user_id=user.id,
+    )
+    db.add(candidate)
+    db.commit()
+
+    request.session["flash"] = f"User created. Temporary password: {temp_password}"
+    return RedirectResponse(url="/admin/users", status_code=303)


### PR DESCRIPTION
## Summary
- convert the admin router into a package with dedicated modules for dashboard views, user management, and applicant workflows
- centralize shared router configuration, templates, and constants so the submodules reuse the same FastAPI router
- keep the existing import path by exporting the router from the new package-level `__init__`

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d3e1d9bc58832dbf87b437f7774cd9