### PR TITLE
Fix candidate applied_on merge artifact

### DIFF
--- a/backend/app/routers/candidates.py
+++ b/backend/app/routers/candidates.py
@@ -5,7 +5,6 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, EmailStr, ValidationError
 from typing import Optional
 from datetime import date, datetime, timezone
-from datetime import date, datetime
 from pathlib import Path
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
@@ -98,17 +97,12 @@ async def api_create_candidate(
     session_email = (session_user.get("email") or "").strip().lower()
     if session_email and session_email == str(payload.email).lower():
         candidate_data["user_id"] = session_user["id"]
+
     if payload.applied_on:
         candidate_data["applied_on"] = datetime.combine(
             payload.applied_on,
             datetime.min.time(),
             tzinfo=timezone.utc,
-        user_id=session_user["id"],
-    )
-    if payload.applied_on:
-        candidate_data["applied_on"] = datetime.combine(
-            payload.applied_on, datetime.min.time()
-
         )
 
     cand = models.Candidate(**candidate_data)


### PR DESCRIPTION
## Summary
- remove stray merge artifact that attempted to pass `user_id` to `datetime.combine` in the candidate creation API
- keep optional applied_on values timezone-aware when stored
- drop the duplicate datetime import caused by the merge

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d4c1b2fdd4832d8c1461e24ac87270