### PR TITLE
Allow candidates without linked user

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -17,7 +17,9 @@ class Candidate(Base):
     status: Mapped[str] = mapped_column(default="Applied")
     applied_on: Mapped[DateTime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id"), nullable=True
+    )
     user: Mapped["User"] = relationship(back_populates="candidates")
     profile: Mapped["CandidateProfile"] = relationship(back_populates="candidate", uselist=False, cascade="all, delete-orphan")
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from fastapi import APIRouter, Depends, HTTPException, Request, Form
 from sqlalchemy.orm import Session
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -5,7 +7,8 @@ from fastapi.templating import Jinja2Templates
 from .. import schemas, crud, database, models
 
 router = APIRouter(prefix="/auth", tags=["auth"])
-templates = Jinja2Templates(directory="templates")
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 
 # GET: show login form

--- a/backend/app/routers/candidates.py
+++ b/backend/app/routers/candidates.py
@@ -5,7 +5,6 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, EmailStr, ValidationError
 from typing import Optional
 from datetime import date, datetime, timezone
-from datetime import date, datetime
 from pathlib import Path
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
@@ -98,17 +97,12 @@ async def api_create_candidate(
     session_email = (session_user.get("email") or "").strip().lower()
     if session_email and session_email == str(payload.email).lower():
         candidate_data["user_id"] = session_user["id"]
+
     if payload.applied_on:
         candidate_data["applied_on"] = datetime.combine(
             payload.applied_on,
             datetime.min.time(),
             tzinfo=timezone.utc,
-        user_id=session_user["id"],
-    )
-    if payload.applied_on:
-        candidate_data["applied_on"] = datetime.combine(
-            payload.applied_on, datetime.min.time()
-
         )
 
     cand = models.Candidate(**candidate_data)


### PR DESCRIPTION
## Summary
- allow Candidate.user_id to be nullable so admins can create candidates without linking their own account

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d4c1b2fdd4832d8c1461e24ac87270