### PR TITLE
Serve Add Employee page from React build

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Follow these steps whenever frontend changes need to be reflected in the backend
 
 4. Visit `http://localhost:8000/candidate-form`. If a React build exists the FastAPI route serves `backend/static/forms/index.html`; otherwise it falls back to the legacy Jinja `templates/index.html`.
 
+### Which screens are React-powered?
+
+- **React + Vite SPA** – the public candidate intake flow (`/candidate-form`) and the admin “Add Employee” screen (`/admin/users/new`) are implemented in React. When you run `npm run build` the bundle is emitted to `backend/static/forms` and transparently picked up by the FastAPI routes. During development you can also visit `http://localhost:5173` while running `npm run dev` for hot reload.
+- **Server-rendered (Jinja)** – the remaining administrative dashboards (`/admin/...`), worker management flows outside of “Add Employee”, and applicant profile management (`/portal/profile`, `/portal/profile/admin/{user_id}`) still rely on the legacy templates. They will look identical to the original implementation until they are rewritten in React.
+
+If you are expecting a screen to be React-driven but it still looks like the legacy version, confirm that it lives under the `/candidate-form` or `/admin/users/new` routes. Anything outside those paths is still backed by the Jinja templates in `backend/templates`.
+
 ## Local development tips
 
 - Run `npm run dev` inside `backend/frontend` for the Vite dev server while working on React components.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -184,6 +184,8 @@ def list_candidates_users(request: Request, db: Session = Depends(get_db)):
 # =========================
 @app.get("/admin/users/new", response_class=HTMLResponse)
 def new_user_form(request: Request):
+    if FRONTEND_INDEX_FILE.exists():
+        return FileResponse(FRONTEND_INDEX_FILE, media_type="text/html")
     return templates.TemplateResponse("user_new.html", {"request": request})
 
 @app.post("/admin/users/new", response_class=HTMLResponse)

--- a/backend/frontend/src/App.tsx
+++ b/backend/frontend/src/App.tsx
@@ -17,6 +17,7 @@ function App() {
         <Route path="/candidate-form" element={<IntakeForm />} />
         <Route path="/evaluation" element={<EvaluationForm />} />
         <Route path="/add-employee" element={<AddEmployee />} />
+        <Route path="/admin/users/new" element={<AddEmployee />} />
         <Route path="/add-training" element={<AddTraining />} />
         <Route path="/applicant-profile" element={<ApplicantProfile />} />
         <Route path="/applicant-profile/form" element={<ApplicantProfileForm />} />


### PR DESCRIPTION
## Summary
- serve the React bundle for `/admin/users/new` when the Vite build is available
- expose the AddEmployee component on the admin path and update documentation to reflect the new SPA coverage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b688dd54832da6d4d959b3535244