### PR TITLE
Serve portal profile from React bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Follow these steps whenever frontend changes need to be reflected in the backend
    before starting Uvicorn.
 
 4. Visit `http://localhost:8000/candidate-form`. If a React build exists the FastAPI route serves `backend/static/forms/index.html`; otherwise it falls back to the legacy Jinja `templates/index.html`.
+   The same SPA bundle now powers `/admin/users/new` and `/portal/profile`, so once the build is in place those pages will render
+   the React experience as well.
+
+### Which screens are React-powered?
+
+- **React + Vite SPA** – the public candidate intake flow (`/candidate-form`), the admin “Add Employee” screen (`/admin/users/new`), and the candidate portal profile (`/portal/profile`, `/portal/profile/admin/{user_id}`) are implemented in React. When you run `npm run build` the bundle is emitted to `backend/static/forms` and transparently picked up by the FastAPI routes. During development you can also visit `http://localhost:5173` while running `npm run dev` for hot reload.
+- **Server-rendered (Jinja)** – the remaining administrative dashboards (`/admin/...`) and worker management flows outside of “Add Employee” still rely on the legacy templates. They will look identical to the original implementation until they are rewritten in React.
+
+If you are expecting a screen to be React-driven but it still looks like the legacy version, confirm that it lives under the `/candidate-form`, `/admin/users/new`, or `/portal/profile` routes. Anything outside those paths is still backed by the Jinja templates in `backend/templates`.
 
 ## Local development tips
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -184,6 +184,8 @@ def list_candidates_users(request: Request, db: Session = Depends(get_db)):
 # =========================
 @app.get("/admin/users/new", response_class=HTMLResponse)
 def new_user_form(request: Request):
+    if FRONTEND_INDEX_FILE.exists():
+        return FileResponse(FRONTEND_INDEX_FILE, media_type="text/html")
     return templates.TemplateResponse("user_new.html", {"request": request})
 
 @app.post("/admin/users/new", response_class=HTMLResponse)

--- a/backend/app/routers/portal.py
+++ b/backend/app/routers/portal.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Form
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
@@ -15,6 +15,8 @@ from ..services import profile as profile_service
 router = APIRouter(prefix="/portal", tags=["portal"])
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+FRONTEND_DIST_DIR = BASE_DIR / "static" / "forms"
+FRONTEND_INDEX_FILE = FRONTEND_DIST_DIR / "index.html"
 
 
 def get_current_user(request: Request, db: Session = Depends(database.get_db)) -> models.User:
@@ -44,6 +46,9 @@ def profile_form(
                 "error": "No candidate record associated with this account.",
             },
         )
+
+    if FRONTEND_INDEX_FILE.exists():
+        return FileResponse(FRONTEND_INDEX_FILE, media_type="text/html")
 
     profile = crud.get_or_create_profile(db, candidate.id)
     return templates.TemplateResponse(
@@ -158,6 +163,9 @@ def profile_admin(
                 "error": "No candidate record linked to this user.",
             },
         )
+
+    if FRONTEND_INDEX_FILE.exists():
+        return FileResponse(FRONTEND_INDEX_FILE, media_type="text/html")
 
     profile = crud.get_or_create_profile(db, candidate.id)
     return templates.TemplateResponse(

--- a/backend/frontend/src/App.tsx
+++ b/backend/frontend/src/App.tsx
@@ -17,8 +17,14 @@ function App() {
         <Route path="/candidate-form" element={<IntakeForm />} />
         <Route path="/evaluation" element={<EvaluationForm />} />
         <Route path="/add-employee" element={<AddEmployee />} />
+        <Route path="/admin/users/new" element={<AddEmployee />} />
         <Route path="/add-training" element={<AddTraining />} />
         <Route path="/applicant-profile" element={<ApplicantProfile />} />
+        <Route path="/portal/profile" element={<ApplicantProfile />} />
+        <Route
+          path="/portal/profile/admin/:userId"
+          element={<ApplicantProfile />}
+        />
         <Route path="/applicant-profile/form" element={<ApplicantProfileForm />} />
         <Route
           path="/applicant-profile/documents"


### PR DESCRIPTION
## Summary
- serve the React bundle for `/admin/users/new` and `/portal/profile` when the Vite build is available
- expose the AddEmployee and candidate portal profile components on the FastAPI paths so the SPA renders for those URLs
- update documentation to reflect the React coverage of the SPA

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b688dd54832da6d4d959b3535244