### PR TITLE
Handle invalid password hashes during login

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,3 +1,5 @@
+import logging
+
 from sqlalchemy.orm import Session
 from . import models, schemas
 from passlib.context import CryptContext
@@ -26,13 +28,19 @@ def get_candidates(db: Session, skip: int = 0, limit: int = 10):
 
 ##
 
+logger = logging.getLogger(__name__)
+
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 def get_password_hash(password: str):
     return pwd_context.hash(password)
 
 def verify_password(plain_password, hashed_password):
-    return pwd_context.verify(plain_password, hashed_password)
+    try:
+        return pwd_context.verify(plain_password, hashed_password)
+    except ValueError:
+        logger.warning("Received invalid password hash when verifying credentials")
+        return False
 
 def create_user(db: Session, user: schemas.UserCreate):
     hashed_pw = get_password_hash(user.password)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -105,6 +105,10 @@ _reexport_models(
         "ProspectiveWorkflow",
         "RiskAssessment",
         "CarePlanGoal",
+        "CarePlanService",
+        "SupportWorker",
+        "CareTeamMember",
+        "ParticipantNote",
     ),
 )
 _reexport_models(
@@ -126,32 +130,9 @@ _reexport_models(
     ),
 )
 
-# Import the richer NDIS domain models so Alembic/Base can discover them.
-# These imports are intentionally placed at the bottom to avoid circular
-# references when the modules import ``Candidate`` or ``User`` from here.
-from .participant import Participant  # noqa: E402,F401
-from .referral import Referral  # noqa: E402,F401
-from .care_plan import (
-    CarePlan,
-    ProspectiveWorkflow,
-    RiskAssessment,
-    CarePlanGoal,
-    CarePlanService,
-    RiskAssessment,
-    SupportWorker,
-    CareTeamMember,
-    ParticipantNote,
-)  # noqa: E402,F401
-from .document import (
-    Document,
-    DocumentAccess,
-    DocumentCategory,
-    DocumentNotification,
-)  # noqa: E402,F401
-from .document_generation import (
-    DocumentGenerationTemplate,
-    GeneratedDocument,
-    DocumentGenerationVariable,
-    DocumentSignature,
-)  # noqa: E402,F401
+# Import the richer NDIS domain models so Alembic/Base can discover them while
+# gracefully handling optional tables.  The ``_reexport_models`` helper above
+# already imports each module and exposes available ORM classes, so we avoid
+# repeating direct ``from .module import ...`` statements that can fail when an
+# expected optional class is absent from the codebase.
 

--- a/backend/tests/test_auth_regression.py
+++ b/backend/tests/test_auth_regression.py
@@ -1,0 +1,74 @@
+"""Regression tests for authentication edge cases."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_DIR = PROJECT_ROOT / "backend"
+
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from app import crud, models  # noqa: E402  (import after path tweak)
+from app.database import Base, get_db  # noqa: E402  (import after path tweak)
+from app.main import app  # noqa: E402  (import after path tweak)
+
+
+@pytest.fixture(name="client_with_db")
+def _client_with_db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    client = TestClient(app)
+
+    try:
+        yield client, TestingSessionLocal
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def test_verify_password_returns_false_for_plaintext_hash():
+    """Unparseable hashes should be treated as invalid credentials."""
+
+    assert crud.verify_password("pw", "plain") is False
+
+
+def test_login_returns_401_for_plaintext_hash(client_with_db):
+    """Users with broken hashes should see a 401 response when logging in."""
+
+    client, TestingSessionLocal = client_with_db
+
+    with TestingSessionLocal() as db:
+        user = models.User(username="plain", email="plain@example.com", hashed_password="plain")
+        db.add(user)
+        db.commit()
+
+    response = client.post("/auth/login", data={"email": "plain@example.com", "password": "pw"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid credentials"

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+# Release Notes
+
+## Authentication Hardening
+
+- Login attempts now treat malformed password hashes as invalid credentials rather than raising an error. Accounts that were created with unhashed passwords should be recreated so that bcrypt hashes are stored correctly. Operators should update affected records by resetting the password through the admin workflow or recreating the user account.


### PR DESCRIPTION
## Summary
- guard `crud.verify_password` so malformed hashes are treated as invalid credentials instead of raising
- add regression tests that cover plain-text hashes and ensure the login endpoint returns HTTP 401
- document the operator action for bad hashes and make optional model imports resilient to missing classes

## Testing
- pytest backend/tests/test_auth_regression.py

------
https://chatgpt.com/codex/tasks/task_e_68d7384da2a0832d9a88005a4982ff3e