### PR TITLE
Ensure portal profile auto-builds frontend assets

### DIFF
--- a/backend/app/core/frontend.py
+++ b/backend/app/core/frontend.py
@@ -1,0 +1,67 @@
+"""Helpers for ensuring the React frontend build is available."""
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+FRONTEND_DIR = BASE_DIR / "frontend"
+FRONTEND_DIST_DIR = BASE_DIR / "static" / "forms"
+FRONTEND_INDEX_FILE = FRONTEND_DIST_DIR / "index.html"
+
+
+def ensure_frontend_build(*, force: bool = False) -> bool:
+    """Ensure the React frontend has been built.
+
+    Returns ``True`` when the ``index.html`` file is present. If it is missing,
+    the function will attempt to run ``npm run build`` in the frontend directory
+    (if npm is available). The helper is intentionally best-effort – failures
+    simply result in returning ``False`` so the caller can fall back to the
+    legacy server rendered template.
+    """
+
+    if FRONTEND_INDEX_FILE.exists() and not force:
+        return True
+
+    if not FRONTEND_DIR.exists():
+        return False
+
+    npm_executable = _find_npm()
+    if not npm_executable:
+        return False
+
+    try:
+        completed = subprocess.run(
+            [npm_executable, "run", "build"],
+            cwd=FRONTEND_DIR,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        logging.getLogger(__name__).info(
+            "Built frontend assets via npm. output=%s", completed.stdout.strip()
+        )
+        if completed.stderr:
+            logging.getLogger(__name__).debug(
+                "npm build stderr: %s", completed.stderr.strip()
+            )
+    except subprocess.CalledProcessError as exc:
+        logging.getLogger(__name__).warning(
+            "Failed to build frontend assets: %s", exc
+        )
+        return False
+
+    return FRONTEND_INDEX_FILE.exists()
+
+
+def _find_npm() -> Optional[str]:
+    """Return the npm executable if it can be located on PATH."""
+
+    for candidate in ("npm", "npm.cmd", "npm.exe"):
+        if shutil.which(candidate):
+            return candidate
+    return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,10 @@ from app.routers import portal as portal_router
 from app.routers import auth as auth_router
 from app.routers import api as api_router
 from app.core.templates import get_templates
+from app.core.frontend import (
+    FRONTEND_INDEX_FILE,
+    ensure_frontend_build,
+)
 from app.services import admin as admin_service
 from app.api.v1.api import api_router as ndis_api_router
 
@@ -34,9 +38,6 @@ app = FastAPI(title="Candidate Intake API")
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = get_templates()
 app.add_middleware(SessionMiddleware, secret_key="super-secret-key")
-
-FRONTEND_DIST_DIR = BASE_DIR / "static" / "forms"
-FRONTEND_INDEX_FILE = FRONTEND_DIST_DIR / "index.html"
 
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 app.mount("/uploads", StaticFiles(directory=str(BASE_DIR / "uploads")), name="uploads")
@@ -66,7 +67,7 @@ def home(request: Request, db: Session = Depends(get_db)):
 
 @app.get("/candidate-form", response_class=HTMLResponse)
 def candidate_form(request: Request):
-    if FRONTEND_INDEX_FILE.exists():
+    if ensure_frontend_build():
         return FileResponse(FRONTEND_INDEX_FILE, media_type="text/html")
     return templates.TemplateResponse("index.html", {"request": request})
 
@@ -184,7 +185,7 @@ def list_candidates_users(request: Request, db: Session = Depends(get_db)):
 # =========================
 @app.get("/admin/users/new", response_class=HTMLResponse)
 def new_user_form(request: Request):
-    if FRONTEND_INDEX_FILE.exists():
+    if ensure_frontend_build():
         return FileResponse(FRONTEND_INDEX_FILE, media_type="text/html")
     return templates.TemplateResponse("user_new.html", {"request": request})
 

--- a/backend/app/routers/portal.py
+++ b/backend/app/routers/portal.py
@@ -15,15 +15,16 @@ from sqlalchemy.orm import Session
 from .. import models, schemas, crud, database
 from ..services import profile as profile_service
 from ..core.templates import get_templates
+from ..core.frontend import (
+    FRONTEND_INDEX_FILE,
+    ensure_frontend_build,
+)
 
 router = APIRouter(prefix="/portal", tags=["portal"])
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 templates = get_templates()
 
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
-
-FRONTEND_DIST_DIR = BASE_DIR / "static" / "forms"
-FRONTEND_INDEX_FILE = FRONTEND_DIST_DIR / "index.html"
 
 
 def get_current_user(request: Request, db: Session = Depends(database.get_db)) -> models.User:
@@ -54,7 +55,7 @@ def profile_form(
             },
         )
 
-    if FRONTEND_INDEX_FILE.exists():
+    if ensure_frontend_build():
         return FileResponse(FRONTEND_INDEX_FILE, media_type="text/html")
 
     profile = crud.get_or_create_profile(db, candidate.id)
@@ -171,7 +172,7 @@ def profile_admin(
             },
         )
 
-    if FRONTEND_INDEX_FILE.exists():
+    if ensure_frontend_build():
         return FileResponse(FRONTEND_INDEX_FILE, media_type="text/html")
 
     profile = crud.get_or_create_profile(db, candidate.id)

--- a/backend/frontend/src/App.tsx
+++ b/backend/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import IntakeForm from "./components/Can-intake-form";
 import EvaluationForm from "./components/EvaluationForm";
@@ -11,7 +12,7 @@ import OfferEmail from "./components/Offer_email";
 import AppShell from "./components/layout/AppShell";
 
 function App() {
-  const withShell = (element: JSX.Element, showLogout = true) => (
+  const withShell = (element: ReactElement, showLogout = true) => (
     <AppShell showLogout={showLogout}>{element}</AppShell>
   );
 
@@ -35,17 +36,6 @@ function App() {
           element={withShell(<ApplicantProfileForm />)}
         />
 
-        <Route path="/evaluation" element={<EvaluationForm />} />
-        <Route path="/add-employee" element={<AddEmployee />} />
-        <Route path="/admin/users/new" element={<AddEmployee />} />
-        <Route path="/add-training" element={<AddTraining />} />
-        <Route path="/applicant-profile" element={<ApplicantProfile />} />
-        <Route path="/portal/profile" element={<ApplicantProfile />} />
-        <Route
-          path="/portal/profile/admin/:userId"
-          element={<ApplicantProfile />}
-        />
-        <Route path="/applicant-profile/form" element={<ApplicantProfileForm />} />
         <Route
           path="/applicant-profile/documents"
           element={withShell(<ApplicantProfileDocument />)}


### PR DESCRIPTION
## Summary
- add a shared helper that ensures the React frontend assets are built (triggering npm run build when needed)
- update FastAPI routes that serve the candidate portal so they now use the helper and automatically switch to the React experience
- clean up the React router configuration and fix its typing so the build succeeds locally

## Testing
- npm run build
- pytest *(fails: existing IndentationError in backend/app/crud.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d765913394832d96095d270aa9babd